### PR TITLE
Max size option

### DIFF
--- a/lib/active_support/cache/database_store.rb
+++ b/lib/active_support/cache/database_store.rb
@@ -21,9 +21,14 @@ module ActiveSupport
       # param [Hash] options options
       # option options [Class] :model model class. Default: ActiveSupport::Cache::DatabaseStore::Model
       # option options [Boolean] :auto_cleanup When true, runs {#cleanup} after every {#write_entry} and {#delete_entry}. Default: false
+      # option options [Integer, nil] :max_size When set (to a positive integer),
+      #    this is the maximum amount of entries that is allowed in the cache.
+      #    Going over will first run {#cleanup} to delete any expired entries.
+      #    If this is not enough, the oldest entry in the cache (based on `created_at` time) will also be deleted. Default: nil
       def initialize(options = nil)
         @model = (options || {}).delete(:model) || Model
         @auto_cleanup = (options || {}).delete(:auto_cleanup) || false
+        @max_size = (options || {}).delete(:max_size) || nil
         super(options)
       end
 
@@ -77,7 +82,16 @@ module ActiveSupport
         expires_at = Time.zone.at(entry.expires_at) if entry.expires_at
         record.update! value: Marshal.dump(entry.value), version: entry.version.presence, expires_at: expires_at
       ensure
-        cleanup if @auto_cleanup
+        cleanup if @auto_cleanup || max_size_exceeded?
+        delete_oldest_entry if max_size_exceeded? # <- Only happens when running cleanup was not enough
+      end
+
+      def max_size_exceeded?
+        @max_size && @model.count > @max_size
+      end
+
+      def delete_oldest_entry
+        @model.order(created_at: :asc).limit(1).destroy_all
       end
 
       def delete_entry(key, _options = nil)

--- a/spec/active_support/cache/database_store_spec.rb
+++ b/spec/active_support/cache/database_store_spec.rb
@@ -335,45 +335,41 @@ RSpec.describe ActiveSupport::Cache::DatabaseStore do
 
       it "cleans up expired entries automatically on write" do
         time = Time.now
-        model = ActiveSupport::Cache::DatabaseStore::Model
-
-        expect(model.count).to eq(0)
+        expect(subject.count(all: true)).to eq(0)
 
         subject.write('one', 'foo', expires_in: 1)
         subject.write('two', 'bar', expires_in: 1)
         subject.write('three', 'baz', expires_in: 1)
 
-        expect(model.count).to eq(3)
+        expect(subject.count(all: true)).to eq(3)
 
         allow(Time).to receive(:now).and_return(time + 11)
 
-        expect(model.count).to eq(3)
+        expect(subject.count(all: true)).to eq(3)
 
         subject.write('four', 'qux', expires_in: 1)
 
-        expect(model.count).to eq(1)
+        expect(subject.count(all: true)).to eq(1)
         expect(subject.read('four')).to eq('qux')
       end
 
       it "cleans up expired entries automatically on delete" do
         time = Time.now
-        model = ActiveSupport::Cache::DatabaseStore::Model
-
-        expect(model.count).to eq(0)
+        expect(subject.count(all: true)).to eq(0)
 
         subject.write('one', 'foo', expires_in: 1)
         subject.write('two', 'bar', expires_in: 1)
         subject.write('three', 'baz', expires_in: 1)
 
-        expect(model.count).to eq(3)
+        expect(subject.count(all: true)).to eq(3)
 
         allow(Time).to receive(:now).and_return(time + 11)
 
-        expect(model.count).to eq(3)
+        expect(subject.count(all: true)).to eq(3)
 
         subject.delete('three')
 
-        expect(model.count).to eq(0)
+        expect(subject.count(all: true)).to eq(0)
       end
     end
 
@@ -384,47 +380,42 @@ RSpec.describe ActiveSupport::Cache::DatabaseStore do
 
       it "no cleanup happens on write" do
         time = Time.now
-        model = ActiveSupport::Cache::DatabaseStore::Model
-
-        expect(model.count).to eq(0)
+        expect(subject.count(all: true)).to eq(0)
 
         subject.write('one', 'foo', expires_in: 1)
         subject.write('two', 'bar', expires_in: 1)
         subject.write('three', 'baz', expires_in: 1)
 
-        expect(model.count).to eq(3)
+        expect(subject.count(all: true)).to eq(3)
 
         allow(Time).to receive(:now).and_return(time + 11)
 
-        expect(model.count).to eq(3)
+        expect(subject.count(all: true)).to eq(3)
 
         subject.write('four', 'qux', expires_in: 1)
 
-        expect(model.count).to eq(4)
+        expect(subject.count(all: true)).to eq(4)
         expect(subject.read('four')).to eq('qux')
       end
     end
 
     it "no cleanup happens on delete" do
       time = Time.now
-      model = ActiveSupport::Cache::DatabaseStore::Model
-
-      expect(model.count).to eq(0)
+      expect(subject.count(all: true)).to eq(0)
 
       subject.write('one', 'foo', expires_in: 1)
       subject.write('two', 'bar', expires_in: 1)
       subject.write('three', 'baz', expires_in: 1)
 
-      expect(model.count).to eq(3)
+      expect(subject.count(all: true)).to eq(3)
 
       allow(Time).to receive(:now).and_return(time + 11)
 
-      expect(model.count).to eq(3)
+      expect(subject.count(all: true)).to eq(3)
 
       subject.delete('three')
 
-      expect(model.count).to eq(2)
+      expect(subject.count(all: true)).to eq(2)
     end
-
   end
 end

--- a/spec/active_support/cache/database_store_spec.rb
+++ b/spec/active_support/cache/database_store_spec.rb
@@ -326,4 +326,32 @@ RSpec.describe ActiveSupport::Cache::DatabaseStore do
       expect(subject.read('foo', version: '1')).to eq('bar')
     end
   end
+
+  describe "auto_cleanup option" do
+    subject do
+      described_class.new auto_cleanup: true
+    end
+
+    it "when set, cleans up expired entries automatically on write" do
+      time = Time.now
+      model = ActiveSupport::Cache::DatabaseStore::Model
+
+      expect(model.count).to eq(0)
+
+      subject.write('one', 'foo', expires_in: 1)
+      subject.write('two', 'bar', expires_in: 1)
+      subject.write('three', 'baz', expires_in: 1)
+
+      expect(model.count).to eq(3)
+
+      allow(Time).to receive(:now).and_return(time + 11)
+
+      expect(model.count).to eq(3)
+
+      subject.write('four', 'qux', expires_in: 1)
+
+      expect(model.count).to eq(1)
+      expect(subject.read('four')).to eq('qux')
+    end
+  end
 end


### PR DESCRIPTION
Implements a `max_size` option that ensures that the cache database table will not exceed a given amount of records.

This PR depends on PR #14 .