### PR TITLE
Create unlogged table for PG cache

### DIFF
--- a/lib/active_support/cache/database_store/migration.rb
+++ b/lib/active_support/cache/database_store/migration.rb
@@ -11,6 +11,24 @@ module ActiveSupport
             t.timestamp :created_at, null: false, index: true
             t.timestamp :expires_at, index: true
           end
+
+          if postgresql?
+            ActiveRecord::Base.connection.execute("ALTER TABLE activesupport_cache_entries SET UNLOGGED")
+          end
+        end
+
+        private
+
+        def adapter
+          if ActiveRecord::VERSION::STRING.to_f >= 6.1
+            ActiveRecord::Base.connection_db_config.adapter.to_s
+          else
+            ActiveRecord::Base.connection_config[:adapter].to_s
+          end
+        end
+
+        def postgresql?
+          adapter =~ /postg/
         end
       end
     end


### PR DESCRIPTION
Good day,

I propose so slightly alter migration script for PostgreSql database -- since [UNLOGGED tables](https://www.crunchydata.com/blog/postgresl-unlogged-tables) seem better suited for cache storage than a regular table.

This patch will trade performance, for data safety. Data safety is not that important for a cache.
