### PR TITLE
Fix race condition when writing a key twice

### DIFF
--- a/spec/active_support/cache/database_store_spec.rb
+++ b/spec/active_support/cache/database_store_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe ActiveSupport::Cache::DatabaseStore do
     marshaled_counter_values = [
       Marshal.dump(0),
       Marshal.dump(1),
-      Marshal.dump(2),
     ]
+    counter = 0
     allow(Marshal).to receive(:dump) {|_value|
       Fiber.yield # Suspend the current fiber
-      marshaled_counter_values[0] # and return a fake payload - we don't care that much about
+      marshaled_counter_values[counter].tap { counter += 1 }
     }
     first_save = Fiber.new do
       expect(subject.write('foo', 0)).to be_truthy

--- a/spec/active_support/cache/database_store_spec.rb
+++ b/spec/active_support/cache/database_store_spec.rb
@@ -36,6 +36,30 @@ RSpec.describe ActiveSupport::Cache::DatabaseStore do
     expect(subject.read('foo')).to eq('baz')
   end
 
+  it 'can deal with a race condition when a stolen write occurs in a concurrent thread or Fiber' do
+    marshaled_counter_values = [
+      Marshal.dump(0),
+      Marshal.dump(1),
+      Marshal.dump(2),
+    ]
+    allow(Marshal).to receive(:dump) {|_value|
+      Fiber.yield # Suspend the current fiber
+      marshaled_counter_values[0] # and return a fake payload - we don't care that much about
+    }
+    first_save = Fiber.new do
+      expect(subject.write('foo', 0)).to be_truthy
+    end
+    second_save = Fiber.new do
+      expect(subject.write('foo', 1)).to be_truthy
+    end
+    first_save.resume
+    second_save.resume
+    first_save.resume
+    second_save.resume
+
+    expect(subject.read('foo')).to eq(0) # First write wins
+  end
+
   it 'supports exist?' do
     subject.write('foo', 'bar')
     expect(subject).to exist('foo')


### PR DESCRIPTION
In some situations when two threads/processes write the same cache key it was possible to get into a race condition. That race condition can be avoided by letting one of the writes win. Since this happens in a very short timeframe letting the first write win is easier.