### PR TITLE
modify cleanup method, to clean up cache without expire_at date

### DIFF
--- a/lib/active_support/cache/database_store.rb
+++ b/lib/active_support/cache/database_store.rb
@@ -26,12 +26,24 @@ module ActiveSupport
       end
 
       # Preemptively iterates through all stored keys and removes the ones which have expired.
+
+      # params [Hash] options
+      # option options [String] :namespace
+      # option options [ActiveSupport::Duration] :outdated_after - provide a time duration after record without expire_at date will get removed.
       def cleanup(options = nil)
         options = merged_options(options)
         scope = @model.expired
+
+        scope = if (outdated_after = options[:outdated_after])
+          scope.or(@model.outdated(outdated_after))
+        else
+          scope.or(@model.outdated)
+        end
+
         if (namespace = options[:namespace])
           scope = scope.namespaced(namespace)
         end
+
         scope.delete_all
       end
 

--- a/lib/active_support/cache/database_store.rb
+++ b/lib/active_support/cache/database_store.rb
@@ -29,15 +29,15 @@ module ActiveSupport
 
       # params [Hash] options
       # option options [String] :namespace
-      # option options [ActiveSupport::Duration] :outdated_after - provide a time duration after record without expire_at date will get removed.
+      # option options [ActiveSupport::Duration] :created_before - provide a time duration after record without expire_at date will get removed.
       def cleanup(options = nil)
         options = merged_options(options)
         scope = @model.expired
 
-        scope = if (outdated_after = options[:outdated_after])
-          scope.or(@model.outdated(outdated_after))
+        scope = if (created_before = options[:created_before])
+          scope.or(@model.created_before(created_before))
         else
-          scope.or(@model.outdated)
+          scope.or(@model.created_before)
         end
 
         if (namespace = options[:namespace])
@@ -48,6 +48,11 @@ module ActiveSupport
       end
 
       # Clears the entire cache. Be careful with this method.
+      #
+      # params [Hash] options
+      # option options [String] :namespace
+      #
+      # @return [Boolean]
       def clear(options = nil)
         options = merged_options(options)
         if (namespace = options[:namespace])

--- a/lib/active_support/cache/database_store.rb
+++ b/lib/active_support/cache/database_store.rb
@@ -34,10 +34,8 @@ module ActiveSupport
         options = merged_options(options)
         scope = @model.expired
 
-        scope = if (created_before = options[:created_before])
-          scope.or(@model.created_before(created_before))
-        else
-          scope.or(@model.created_before)
+        if (created_before = options[:created_before])
+          scope = scope.or(@model.created_before(created_before))
         end
 
         if (namespace = options[:namespace])

--- a/lib/active_support/cache/database_store/model.rb
+++ b/lib/active_support/cache/database_store/model.rb
@@ -12,15 +12,13 @@ module ActiveSupport
 
         scope :fresh, -> { where(arel_table[:expires_at].gt(Time.zone.now)) }
         scope :expired, -> { where(arel_table[:expires_at].lteq(Time.zone.now)) }
-        scope :outdated, -> (date = 1.month.ago) { where(arel_table[:created_at].lt(date)) }
+        scope :created_before, -> (date = 1.month.ago) { where(arel_table[:created_at].lt(date)) }
 
         def self.namespaced(namespace)
           prefix = "#{namespace}:"
           clause = ::Arel::Nodes::NamedFunction.new('SUBSTR', [arel_table[:key], 1, prefix.bytesize])
           where clause.eq(prefix)
         end
-
-
       end
     end
   end

--- a/lib/active_support/cache/database_store/model.rb
+++ b/lib/active_support/cache/database_store/model.rb
@@ -12,12 +12,15 @@ module ActiveSupport
 
         scope :fresh, -> { where(arel_table[:expires_at].gt(Time.zone.now)) }
         scope :expired, -> { where(arel_table[:expires_at].lteq(Time.zone.now)) }
+        scope :outdated, -> (date = 1.month.ago) { where(arel_table[:created_at].lt(date)) }
 
         def self.namespaced(namespace)
           prefix = "#{namespace}:"
           clause = ::Arel::Nodes::NamedFunction.new('SUBSTR', [arel_table[:key], 1, prefix.bytesize])
           where clause.eq(prefix)
         end
+
+
       end
     end
   end

--- a/lib/active_support/cache/database_store/model.rb
+++ b/lib/active_support/cache/database_store/model.rb
@@ -12,7 +12,7 @@ module ActiveSupport
 
         scope :fresh, -> { where(arel_table[:expires_at].gt(Time.zone.now)) }
         scope :expired, -> { where(arel_table[:expires_at].lteq(Time.zone.now)) }
-        scope :created_before, -> (date = 1.month.ago) { where(arel_table[:created_at].lt(date)) }
+        scope :created_before, ->(date = 1.month.ago) { where(arel_table[:created_at].lt(date)) }
 
         def self.namespaced(namespace)
           prefix = "#{namespace}:"

--- a/spec/active_support/cache/database_store_spec.rb
+++ b/spec/active_support/cache/database_store_spec.rb
@@ -120,6 +120,21 @@ RSpec.describe ActiveSupport::Cache::DatabaseStore do
       expect(subject.read('fud')).to eq('biz')
     end
 
+    it 'remove old cache without expires_in value' do
+      time = Time.now
+
+      subject.write('this', 'expired', expires_in: nil)
+
+      allow(Time).to receive(:now).and_return(time + 32.days)
+      expect(subject.cleanup).to eq(1)
+
+      subject.write('not', 'expired', expires_in: nil)
+      allow(Time).to receive(:now).and_return(time + 15.days)
+      expect(subject.cleanup).to eq(0)
+
+      expect(subject.cleanup(outdated_after: 10.days.ago)).to eq(1)
+    end
+
     it 'supports namespace' do
       time = Time.now
       subject.write('foo', 'bar', expires_in: 10, namespace: 'x')

--- a/spec/active_support/cache/database_store_spec.rb
+++ b/spec/active_support/cache/database_store_spec.rb
@@ -124,12 +124,6 @@ RSpec.describe ActiveSupport::Cache::DatabaseStore do
     end
 
     it 'remove old cache without expires_in value' do
-      subject.write('this', 'expired', expires_in: nil)
-
-      travel 32.days do
-        expect(subject.cleanup).to eq(1)
-      end
-
       subject.write('not', 'expired', expires_in: nil)
 
       travel 15.days do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV['RACK_ENV'] ||= 'test'
 require 'rspec'
 require 'fileutils'
 require 'activesupport_cache_database'
+require 'active_support/testing/time_helpers'
 
 Time.zone_default = Time.find_zone!('UTC')
 


### PR DESCRIPTION
`.cleanup` method was modified to include records that are created older than 1 month. This is possible to override this duration  with `created_before:` parameter. 