### PR TITLE
Don't run Rubocop multiple times on Github Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.0"
           bundler-cache: true
       - run: bundle exec rake rubocop
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
 
 jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rake rubocop
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -21,4 +29,4 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - run: bundle exec rake
+      - run: bundle exec rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  formatting:
+  rubocop:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Github Action CI is executing rubocop multiple times through the version matrix. 

- There is no need to waste CI resources for that. 
- But formatting failure is also shown as failing test for all ruby versions, which is misleading.