### PR TITLE
Use partial index for expires_at column

### DIFF
--- a/lib/active_support/cache/database_store/migration.rb
+++ b/lib/active_support/cache/database_store/migration.rb
@@ -7,7 +7,7 @@ module ActiveSupport
         def change
           create_table :activesupport_cache_entries, primary_key: 'key', id: :binary, limit: 255 do |t|
             t.binary :value, null: false
-            t.string :version, index: true
+            t.string :version
             t.timestamp :created_at, null: false, index: true
             t.timestamp :expires_at
           end
@@ -15,9 +15,11 @@ module ActiveSupport
           if mysql?
             # MySQL and MariaDB don't support partial indexes
             add_index :activesupport_cache_entries, :expires_at
+            add_index :activesupport_cache_entries, :version
           else
             # For Sqlite3, PostgreSQL we use partial index, because expires_at column can be null it would be wasteful to include it in index
             add_index :activesupport_cache_entries, :expires_at, where: 'expires_at IS NOT NULL'
+            add_index :activesupport_cache_entries, :version, where: 'version IS NOT NULL'
           end
         end
 

--- a/lib/active_support/cache/database_store/migration.rb
+++ b/lib/active_support/cache/database_store/migration.rb
@@ -9,8 +9,30 @@ module ActiveSupport
             t.binary :value, null: false
             t.string :version, index: true
             t.timestamp :created_at, null: false, index: true
-            t.timestamp :expires_at, index: true
+            t.timestamp :expires_at
           end
+
+          if mysql?
+            # MySQL and MariaDB don't support partial indexes
+            add_index :activesupport_cache_entries, :expires_at
+          else
+            # For Sqlite3, PostgreSQL we use partial index, because expires_at column can be null it would be wasteful to include it in index
+            add_index :activesupport_cache_entries, :expires_at, where: 'expires_at IS NOT NULL'
+          end
+        end
+
+        private
+
+        def adapter
+          if ActiveRecord::VERSION::STRING.to_f >= 6.1
+            ActiveRecord::Base.connection_db_config.adapter.to_s
+          else
+            ActiveRecord::Base.connection_config[:adapter].to_s
+          end
+        end
+
+        def mysql?
+          adapter =~ /mysql/
         end
       end
     end

--- a/lib/active_support/cache/database_store/migration.rb
+++ b/lib/active_support/cache/database_store/migration.rb
@@ -32,7 +32,7 @@ module ActiveSupport
         end
 
         def mysql?
-          adapter =~ /mysql/
+          adapter.include?('mysql')
         end
       end
     end


### PR DESCRIPTION
For Sqlite3, PostgreSQL we should use partial index, because `expires_at` and `version` columns can be null it would be wasteful to include it in index. 

Turns out that MariaDB and Mysql doesn't support partial indexes. Though, MariaDB is planning to fix that:
https://jira.mariadb.org/browse/MDEV-15140
            
            
     