### PR TITLE
convert primary index to hash index

### DIFF
--- a/lib/generators/cache/database/install_generator.rb
+++ b/lib/generators/cache/database/install_generator.rb
@@ -15,7 +15,8 @@ module Cache
         end
 
         def copy_migrations
-          migration_template 'create_table_for_cache.rb', 'db/migrate/create_cache_database.rb'
+          migration_template 'create_table_for_cache.rb', 'db/migrate/create_table_for_cache.rb'
+          migration_template 'create_primary_key_index.rb', 'db/migrate/create_primary_key_index.rb'
         end
       end
     end

--- a/lib/generators/cache/database/templates/create_primary_key_index.rb
+++ b/lib/generators/cache/database/templates/create_primary_key_index.rb
@@ -1,0 +1,13 @@
+class CreatePrimaryKeyIndex < ActiveRecord::Migration[7.0]
+  def up
+    execute <<-SQL
+      CREATE INDEX activesupport_cache_entries_key_index ON public.activesupport_cache_entries USING HASH (key);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP INDEX activesupport_cache_entries_key_index;
+    SQL
+  end
+end


### PR DESCRIPTION
Hash index offers a faster record lookup, it’s a O(1) operation and is being done without a need to descent through index as B-TREE index does. Based [on this article](http://amitkapila16.blogspot.com/2017/03/hash-indexes-are-faster-than-btree.html), it’s expected that hash indexes would improve performance of cache entry lookup by 40-60%.

## Benefits
- Smaller index size, because hash index is stored just as 4-byte hash value. And they will take up significantly less space, than our current lengthy keys.
- Hash index can work with any data and in our case string/bytes will do.
- Speed of record lookup is significantly faster and doesn’t degrade if there are more records
- After PG 10 this index change is written to WAL and this data could be recovered, not the case for older versions of pg and not a dealbreaker for cache table anyway.

## Downsides
- Don’t support duplicated data, but since this is a primary key this is not an issue for this gem.
- Supports only single column indexes, but since this is a primary key - not an issue for this gem.
- Supports only equal (=) operator to retrieve records - that is the only lookup we do.